### PR TITLE
Restore Python 2 compat

### DIFF
--- a/threadlocals/middleware.py
+++ b/threadlocals/middleware.py
@@ -14,7 +14,7 @@ as modified by [http://sct.sphene.net Sphene Community tools].
 (see license.txt)
 """
 
-from threadlocals.threadlocals import set_thread_variable
+from .threadlocals import set_thread_variable
 
 class ThreadLocalMiddleware(object):
     """Middleware that puts the request object in thread local storage."""


### PR DESCRIPTION
@nanuxbe helpfully pointed out that my previous PR added Python 3 compat but broke Python 2. This form should work in both.